### PR TITLE
fix: update GitHub Actions versions due to Node.js 16 deprecation

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,10 +16,10 @@ jobs:
         run: echo "Hello World!"
 
       # - name: Checkout
-      #   uses: actions/checkout@v3
+      #   uses: actions/checkout@v4
 
       # - name: Setup Python
-      #   uses: actions/setup-python@v3
+      #   uses: actions/setup-python@v5
 
       # - name: Install Python requirements
       #   run: pip3 install -r requirements.txt
@@ -28,7 +28,7 @@ jobs:
       #   uses: pre-commit/action@v3.0.0
 
       # - name: Check paths for sites/site_1
-      #   uses: dorny/paths-filter@v2
+      #   uses: dorny/paths-filter@v3
       #   id: filter-site1
       #   with:
       #     filters: |
@@ -36,7 +36,7 @@ jobs:
       #         - 'sites/site_1/**'
 
       # - name: Check paths for sites/site_2
-      #   uses: dorny/paths-filter@v2
+      #   uses: dorny/paths-filter@v3
       #   id: filter-site2
       #   with:
       #     filters: |

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -16,10 +16,10 @@ jobs:
         run: echo "Hello World!"
 
       # - name: Checkout
-      #   uses: actions/checkout@v3
+      #   uses: actions/checkout@v4
 
       # - name: Setup Python
-      #   uses: actions/setup-python@v3
+      #   uses: actions/setup-python@v5
 
       # - name: Install Python requirements
       #   run: pip3 install -r requirements.txt
@@ -28,7 +28,7 @@ jobs:
       #   uses: pre-commit/action@v3.0.0
 
       # - name: Check paths for sites/site_1
-      #   uses: dorny/paths-filter@v2
+      #   uses: dorny/paths-filter@v3
       #   id: filter-site1
       #   with:
       #     filters: |
@@ -36,7 +36,7 @@ jobs:
       #         - 'sites/site_1/**'
 
       # - name: Check paths for sites/site_2
-      #   uses: dorny/paths-filter@v2
+      #   uses: dorny/paths-filter@v3
       #   id: filter-site2
       #   with:
       #     filters: |


### PR DESCRIPTION
Update GitHub Actions versions due to Node.js 16 deprecation (in favor of Node.js 20)

I ran into issues with the CI/CD lab on ATD and had to update the Actions versions in `dev.yml` and `prod.yml`
Solves issue #87 

**Note:** I will also be submitting a PR to `avd-workshops` that will reflect these changes in the lab documentation.