### PR TITLE
Fix(global_vars): remove mgmt_interface

### DIFF
--- a/global_vars/global_dc_vars.yml
+++ b/global_vars/global_dc_vars.yml
@@ -30,7 +30,6 @@ aaa_authorization:
 
 # OOB Management network default gateway.
 mgmt_gateway: 192.168.0.1
-mgmt_interface: Management0
 mgmt_interface_vrf: default
 
 # NTP Servers IP or DNS name, first NTP server will be preferred, and sourced from Management VRF


### PR DESCRIPTION
This variable is hard coding something that is set by eos_designs `platform: cEOS` in the FABRIC files in site 1 and site 2.

I wanted to show the abstraction of the platform settings during a workshop and it was not working due to this variable.