### PR TITLE
Quality of Life - Added file lookup for ssh-key

### DIFF
--- a/global_vars/global_dc_vars.yml
+++ b/global_vars/global_dc_vars.yml
@@ -22,6 +22,7 @@ local_users:
     privilege: 15
     role: network-admin
     sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista') }}"
+    ssh_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 # AAA
 aaa_authorization:


### PR DESCRIPTION
The ATD lab environments populate all the switches with the ssh-key of the hosted vscode instance by default but when we push config with AVD during the workshop we overwrite this, making SSH'ing into the devices to check the impact of AVD more tedious involving typing in the lab password repeatedly. This resolves that by pushing the ssh-key as part of the AVD data model. 