### PR TITLE
add rounds to password_hash in global vars

### DIFF
--- a/labs/L2LS/complete/global_vars/global_dc_vars.yml
+++ b/labs/L2LS/complete/global_vars/global_dc_vars.yml
@@ -21,7 +21,7 @@ local_users:
   - name: arista
     privilege: 15
     role: network-admin
-    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista') }}"
+    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista', rounds=5000) }}"
 
 # AAA
 aaa_authorization:

--- a/labs/L2LS/global_vars/global_dc_vars.yml
+++ b/labs/L2LS/global_vars/global_dc_vars.yml
@@ -21,7 +21,7 @@ local_users:
   - name: arista
     privilege: 15
     role: network-admin
-    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista') }}"
+    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista', rounds=5000) }}"
     ssh_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 # AAA

--- a/labs/L3LS_EVPN/global_vars/global_dc_vars.yml
+++ b/labs/L3LS_EVPN/global_vars/global_dc_vars.yml
@@ -25,7 +25,7 @@ local_users:
   - name: arista
     privilege: 15
     role: network-admin
-    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista') }}"
+    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista', rounds=5000) }}"
     ssh_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 # AAA

--- a/labs/NET_TESTING/global_vars/global_dc_vars.yml
+++ b/labs/NET_TESTING/global_vars/global_dc_vars.yml
@@ -25,7 +25,7 @@ local_users:
   - name: arista
     privilege: 15
     role: network-admin
-    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista') }}"
+    sha512_password: "{{ ansible_password | password_hash('sha512', salt='arista', rounds=5000) }}"
     ssh_key: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
 
 # AAA


### PR DESCRIPTION
adding number of rounds for password_hash filter.  the current ouput injects the default rounds value in the hashed output if not defined

![Screenshot from 2025-02-19 15-13-51](https://github.com/user-attachments/assets/3ee54c6a-0e42-48ce-a66e-d175ec9c4733)

This config fails on EOS when deploying.