### PR TITLE
Removing use_anta keys that are no longer required

### DIFF
--- a/labs/NET_TESTING/playbooks/validate.yml
+++ b/labs/NET_TESTING/playbooks/validate.yml
@@ -10,6 +10,4 @@
       ansible.builtin.import_role:
         name: arista.avd.eos_validate_state
       # vars:
-        # use_anta: true
         # save_catalog: true
-        # eos_validate_state_md_report_path: "{{ eos_validate_state_dir }}/{{ fabric_name }}-state-anta.md"


### PR DESCRIPTION
With the update to AVD 5.0 in the workshops, use_anta: true is no longer required.